### PR TITLE
Add AGENTS.md for cloud agent development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Agent Instructions
+
+## Cursor Cloud specific instructions
+
+### Node version
+
+This project requires Node.js v20.18.2 exactly. The version is pinned in `.nvmrc`.
+nvm is installed at `$HOME/.nvm`. Source it before running any node commands:
+
+```
+export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh" && nvm use 20.18.2
+```
+
+### Build pipeline
+
+The build has three stages that must run in order:
+
+1. `npm run buildreact` -- builds the React UI components under `src/vs/workbench/contrib/void/browser/react/`
+2. `npm run compile` -- runs the gulp-based TypeScript compilation (takes ~2-3 min, uses `--max-old-space-size=8192` internally)
+3. The web dev server or Electron app can then be launched
+
+If you only change React code, you only need to re-run step 1. For other TS changes, step 2 is needed.
+
+### Running the app
+
+- **Web version** (headless-friendly, no display needed): `node ./scripts/code-web.js --host 0.0.0.0 --port 8080 --browserType none`
+- **Electron desktop** (needs X11/Xvfb): `./scripts/code.sh` -- the script auto-detects docker and adds `--disable-dev-shm-usage`
+- **Watch mode** for incremental dev: `npm run watch` (runs both client and extensions watchers)
+
+### Testing
+
+- Unit tests: `npm run test-node` -- runs mocha-based Node tests (~4500 tests, ~11s)
+- Browser tests: `npm run test-browser` -- needs playwright installed first
+- See `scripts/test.sh` and `scripts/test-integration.sh` for integration tests
+
+### Linting
+
+- `npm run eslint` -- note: as of the current codebase, this emits a ts-node compilation error related to `moduleResolution` settings but still exits 0. This is a pre-existing issue.
+- `npm run hygiene` -- runs the gulp hygiene task
+
+### System deps (Linux)
+
+The native modules (node-pty, kerberos, native-keymap) need these packages:
+`build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev libkrb5-dev python-is-python3`
+
+For running the Electron app: `libnss3 libgtk-3-0 libgbm1 libxss1 libasound2t64`
+
+For headless Electron: install `xvfb` and run via `xvfb-run`.
+
+### Gotchas
+
+- npm is the only supported package manager. yarn is rejected by `build/npm/preinstall.js`.
+- The `postinstall` script downloads the Electron binary; this can be slow on first run.
+- The chrome-sandbox may need permissions fix: `sudo chown root:root .build/electron/chrome-sandbox && sudo chmod 4755 .build/electron/chrome-sandbox`
+- If you see "Cannot find module '../react/out/..." errors, run `npm run buildreact` before `npm run compile`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions including:

- Node.js version requirement (v20.18.2) and nvm setup
- Build pipeline order (buildreact -> compile -> run)
- Running the app (web version, Electron, watch mode)
- Testing commands (unit tests, browser tests, integration)
- Linting notes (eslint ts-node issue documented)
- System dependency requirements for Linux
- Common gotchas (npm-only, chrome-sandbox permissions, React build ordering)

### Environment verification

All core development workflows were verified:

| Check | Result |
|-------|--------|
| `npm install` | Passed |
| `npm run buildreact` | Passed |
| `npm run compile` | Passed (0 errors, 2.53 min) |
| `npm run test-node` | Passed (4489 passing, 110 pending) |
| `npm run eslint` | Exit 0 (pre-existing ts-node config warning) |
| Web server (`code-web.js`) | Running on port 8080 |

### Demo

[vs_aware_demo_hello_world.mp4](https://cursor.com/agents/bc-17c6c541-1575-4607-a739-de5203d6d704/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvs_aware_demo_hello_world.mp4)

VS Aware web editor loading, creating a new file, typing Python code, and applying syntax highlighting via the command palette.

[Python syntax highlighting in VS Aware](https://cursor.com/agents/bc-17c6c541-1575-4607-a739-de5203d6d704/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvs_aware_python_syntax.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c6c541-1575-4607-a739-de5203d6d704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c6c541-1575-4607-a739-de5203d6d704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

